### PR TITLE
fix: corrigir asset quebrado na documentação adotando caminho absoluto

### DIFF
--- a/general/general-shortcuts.md
+++ b/general/general-shortcuts.md
@@ -1,6 +1,6 @@
 # General Shortcuts
 
-![Shortcuts examples](../assets/general/general-shortcuts/shortcuts-perssua.png)
+![Shortcuts examples](/assets/general/general-shortcuts/shortcuts-perssua.png)
 
 ## Overview
 The app includes a set of keyboard shortcuts to improve speed and usability. These allow you to quickly change visibility, capture screenshots, scroll through the Perssua chat, and record or analyze audio without leaving the main workflow.

--- a/general/pt/general-shortcuts.md
+++ b/general/pt/general-shortcuts.md
@@ -1,6 +1,6 @@
 # Atalhos Gerais
 
-![Exemplos de atalhos](../assets/general/general-shortcuts/shortcuts-perssua.png)
+![Exemplos de atalhos](/assets/general/general-shortcuts/shortcuts-perssua.png)
 
 ## Visão Geral
 O app inclui um conjunto de atalhos de teclado para melhorar a velocidade e a usabilidade. Eles permitem alternar a visibilidade, capturar screenshots, rolar o chat do Perssua e gravar ou analisar áudio sem sair do fluxo principal.


### PR DESCRIPTION
### Problema

Esta PR corrige o problema de asset quebrado na documentação pt-br. O link da imagem estava utilizando um caminho relativo incorreto, o que fazia com que o asset não fosse exibido corretamente em determinadas traduções da doc.

<img width="1001" height="369" alt="image" src="https://github.com/user-attachments/assets/dd5abda8-7575-4c2d-a70f-9bec1b8c2d18" />

### O que foi feito ?

Adotado o uso de caminho absoluto (`/assets/...`) para garantir consistência e evitar problemas com diferentes níveis de pastas entre traduções.